### PR TITLE
Fixed saving of the currently opened Data.wz file

### DIFF
--- a/HaRepacker/WzFileManager.cs
+++ b/HaRepacker/WzFileManager.cs
@@ -104,17 +104,21 @@ namespace HaRepacker
         /// <returns></returns>
         public WzImage LoadDataWzHotfixFile(string path, WzMapleVersion encVersion, MainPanel panel)
         {
-            FileStream fs = File.Open(path, FileMode.Open);
+            WzImage img;
 
-            WzImage img = new WzImage(Path.GetFileName(path), fs, encVersion);
-            img.ParseImage(true);
-
-            WzNode node = new WzNode(img);
-            panel.DataTree.Nodes.Add(node);
-            if (Program.ConfigurationManager.UserSettings.Sort)
+            using (FileStream fs = File.Open(path, FileMode.Open))
             {
-                SortNodesRecursively(node);
+                img = new WzImage(Path.GetFileName(path), fs, encVersion);
+                img.ParseImage(true);
+
+                WzNode node = new WzNode(img);
+                panel.DataTree.Nodes.Add(node);
+                if (Program.ConfigurationManager.UserSettings.Sort)
+                {
+                    SortNodesRecursively(node);
+                }
             }
+
             return img;
 
         }


### PR DESCRIPTION
You cannot save `Data.wz` files after editing them as the `FileStream` doesn't close.
This patch fixes the issue by wrapping the `FileStream` in a `using` statement, making it exception safe as well.
I did minimal testing and have seen no issues.