### PR TITLE
Fixed an issue decoding Map001.wz (msea v194.1)

### DIFF
--- a/HaRepacker/GUI/Panels/MainPanel.xaml.cs
+++ b/HaRepacker/GUI/Panels/MainPanel.xaml.cs
@@ -727,7 +727,7 @@ namespace HaRepacker.GUI.Panels
 
             // Set tooltip text
             if (i_animateCanvasNode == animate_PreLoadImages.Count)
-                statusBarItemLabel_Others.Text = "# " + currentSelectedFrame.Name + ", Delay: " + currentSelectedFrame.Delay + " ms. Repeating Animate.";
+                statusBarItemLabel_Others.Text = "# " + currentSelectedFrame.Name + ", Delay: " + currentSelectedFrame.Delay + " ms. Repeating animation.";
             else
                 statusBarItemLabel_Others.Text = "# " + currentSelectedFrame.Name + ", Delay: " + currentSelectedFrame.Delay + " ms.";
 
@@ -1438,7 +1438,8 @@ namespace HaRepacker.GUI.Panels
                 canvasPropBox.CanvasVectorHead = headVector;
                 canvasPropBox.CanvasVectorLt = ltVector;
             }
-            canvasPropBox.Visibility = Visibility.Visible;
+            if (canvasPropBox.Visibility != Visibility.Visible)
+                canvasPropBox.Visibility = Visibility.Visible;
         }
         #endregion
 

--- a/HaRepacker/Program.cs
+++ b/HaRepacker/Program.cs
@@ -23,7 +23,7 @@ namespace HaRepacker
         public const string Version = "4.2.4";
         public const int Version_ = 424;
 
-        public const int TimeStartAnimateDefault = 60;
+        public const int TimeStartAnimateDefault = 10;
 
         public static WzFileManager WzMan = new WzFileManager();
         public static NamedPipeServerStream pipe;

--- a/MapleLib/WzLib/WzDirectory.cs
+++ b/MapleLib/WzLib/WzDirectory.cs
@@ -19,6 +19,7 @@ using System.IO;
 using MapleLib.WzLib.Util;
 using System;
 using System.Diagnostics;
+using MapleLib.PacketLib;
 
 namespace MapleLib.WzLib
 {
@@ -176,6 +177,9 @@ namespace MapleLib.WzLib
         /// </summary>
         internal void ParseDirectory(bool lazyParse = false)
         {
+            //Debug.WriteLine(HexTool.ToString( reader.ReadBytes(20)));
+            //reader.BaseStream.Position = reader.BaseStream.Position - 20;
+
             int entryCount = reader.ReadCompressedInt();
             for (int i = 0; i < entryCount; i++)
             {


### PR DESCRIPTION
Coincidentally in msea v194 Map001.wz:
The hash matches exactly, and it fails to decrypt later on (probably 1 in a million chance)

mapleStoryPatchVersion used = 113