### PR TITLE
[MapleLib] Fixed copyright header parsing (#77)

### DIFF
--- a/MapleLib/WzLib/WzFile.cs
+++ b/MapleLib/WzLib/WzFile.cs
@@ -206,14 +206,14 @@ namespace MapleLib.WzLib
             }
             WzBinaryReader reader = new WzBinaryReader(File.Open(this.path, FileMode.Open, FileAccess.Read, FileShare.Read), WzIv);
 
-            this.Header = new WzHeader
-            {
-                Ident = reader.ReadString(4),
-                FSize = reader.ReadUInt64(),
-                FStart = reader.ReadUInt32(),
-                Copyright = reader.ReadNullTerminatedString()
-            };
-            reader.ReadBytes((int)(Header.FStart - reader.BaseStream.Position));
+            this.Header = new WzHeader();
+            this.Header.Ident = reader.ReadString(4);
+            this.Header.FSize = reader.ReadUInt64();
+            this.Header.FStart = reader.ReadUInt32();
+            this.Header.Copyright = reader.ReadString((int)(Header.FStart - 17U));
+
+            reader.ReadBytes(1);
+            reader.ReadBytes((int)(Header.FStart - (ulong)reader.BaseStream.Position));
             reader.Header = this.Header;
             this.version = reader.ReadInt16();
 


### PR DESCRIPTION
Closes #77.

This patch fixes parsing for the copyright part in the WZ file's header and therefore, fixes parsing for WZ files that were produced by the ancient versions of HaCreator. I found that the issue happens because the game client reads a fixed amount of bytes for the copyright string however the old version of MapleLib for some reason wrote a 50 instead of a 0 (null terminator) at the end of the string, therefore -- breaking it all apart

It's a bit hacky (and hardcoded). I accomplished it by reversing the parsing from the MapleLib library I had which happened to have the correct parsing patched into it. 

I have tested this patch on various WZ files including stock v83, a variety of modded v83s, stock v84, v92, v95, v127, v162, v176, stock v179, Kastia's v179, v213.. all seems well!