### PR TITLE
allow 64 bit addresses in SharpApngBasicWrapper Marshalling

### DIFF
--- a/HaSharedLibrary/SharpApng/SharpApngBasicWrapper.cs
+++ b/HaSharedLibrary/SharpApng/SharpApngBasicWrapper.cs
@@ -43,7 +43,8 @@ namespace HaSharedLibrary.SharpApng
             int size = Marshal.SizeOf(source[0]) * source.Length;
             IntPtr pnt = Marshal.AllocHGlobal(size);
             Marshal.Copy(toMarshal, 0, pnt, source.Length);
-            Marshal.Copy(new byte[] { 0 }, 0, new IntPtr(pnt.ToInt32() + size), 1);
+            IntPtr dest = Environment.Is64BitProcess ? new IntPtr(pnt.ToInt64() + size) : new IntPtr(pnt.ToInt32() + size);
+            Marshal.Copy(new byte[] { 0 }, 0, dest, 1);
             return pnt;
         }
 


### PR DESCRIPTION
Fixes the issue mentioned here, encountered while exporting animations: https://github.com/lastbattle/Harepacker-resurrected/issues/78#issuecomment-853157170 

Uses the fix mentioned here: https://stackoverflow.com/a/36480919

> The error is caused by your code running in a 64 bit context and returning a pointer address that lies outside the range addressable with 32 bits, so .ToInt32() throws.

> Call Environment.Is64BitProcess to detect whether your process is running in 32 or 64 bit, and convert the address accordingly.

Note that I didn't regression-test this, nor did I find a test suite; it's up to the maintainer to test this out.