### PR TITLE
[MapleLib] Fix nulled LinkValue when path is not endwith ".img"

### DIFF
--- a/MapleLib/WzLib/WzProperties/WzUOLProperty.cs
+++ b/MapleLib/WzLib/WzProperties/WzUOLProperty.cs
@@ -153,15 +153,20 @@ namespace MapleLib.WzLib.WzProperties
 						{
                             if (linkVal is WzImageProperty)
                                 linkVal = ((WzImageProperty)linkVal)[path];
-                            else if (linkVal is WzImage image)
+                            else if (linkVal is WzImage image) 
                                 linkVal = image[path];
-                            else if (linkVal is WzDirectory directory)
-                                linkVal = directory[path];
-                            else
-                            {
-                                MapleLib.Helpers.ErrorLogger.Log(MapleLib.Helpers.ErrorLevel.Critical, "UOL got nexon'd at property: " + this.FullPath);
-                                return null;
-                            }
+							else if (linkVal is WzDirectory directory)
+							{
+								if (path.EndsWith(".img"))
+									linkVal = directory[path];
+								else
+									linkVal = directory[path + ".img"];
+							}
+							else
+							{
+								MapleLib.Helpers.ErrorLogger.Log(MapleLib.Helpers.ErrorLevel.Critical, "UOL got nexon'd at property: " + this.FullPath);
+								return null;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Some WZUOLProperty has null LinkValue
e.g. Mob001.wz/8800002.img/boss_body2.png has path "../8800102/boss_body2.png"
The "8800102" is WzImage name but not endwith ".img"

![image](https://user-images.githubusercontent.com/3710930/132922405-f427eded-2653-4c9b-b87f-5e5774891f98.png)
