### PR TITLE
Fallback for wz saving and clipboard cleanup

### DIFF
--- a/HaCreator/HaCreator.csproj
+++ b/HaCreator/HaCreator.csproj
@@ -841,7 +841,7 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="SharpDX">
       <Version>4.2.0</Version>

--- a/HaRepacker/GUI/ContextMenuManager.cs
+++ b/HaRepacker/GUI/ContextMenuManager.cs
@@ -385,6 +385,7 @@ namespace HaRepacker
             else if (Tag is WzFile)
             {
                 toolStripmenuItems.Add(AddDirsSubMenu);
+                toolStripmenuItems.Add(Rename);
                 toolStripmenuItems.Add(SaveFile);
                 toolStripmenuItems.Add(Unload);
                 toolStripmenuItems.Add(Reload);

--- a/HaRepacker/GUI/Panels/MainPanel.xaml.cs
+++ b/HaRepacker/GUI/Panels/MainPanel.xaml.cs
@@ -1308,6 +1308,12 @@ namespace HaRepacker.GUI.Panels
             if (!Warning.Warn(Properties.Resources.MainConfirmCopy) || bPasteTaskActive)
                 return;
 
+            foreach (WzObject obj in clipboard)
+            {
+                //this causes minor weirdness with png's in copied nodes but otherwise memory is not free'd 
+                obj.Dispose();
+            }
+
             clipboard.Clear();
 
             foreach (WzNode node in DataTree.SelectedNodes)

--- a/HaRepacker/GUI/SaveForm.cs
+++ b/HaRepacker/GUI/SaveForm.cs
@@ -166,8 +166,14 @@ namespace HaRepacker.GUI
                     {
                         wzf.SaveToDisk(dialog.FileName + "$tmp", wzMapleVersionSelected);
                         wzNode.DeleteWzNode();
-                        File.Delete(dialog.FileName);
-                        File.Move(dialog.FileName + "$tmp", dialog.FileName);
+                        try
+                        {
+                            File.Delete(dialog.FileName);
+                            File.Move(dialog.FileName + "$tmp", dialog.FileName);
+                        }catch(IOException ex)
+                        {
+                            MessageBox.Show("Handle error overwriting WZ file", HaRepacker.Properties.Resources.Error);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
Renaming wz files becomes an actually kind of relevant thing with new structure so added that in along with syncing newtonsoft package version for hacreator to match the rest 