### PR TITLE
[HaRepacker] fix remove node '_hash' in FixLinkForOldMS

### DIFF
--- a/HaRepacker/GUI/Panels/MainPanel.xaml.cs
+++ b/HaRepacker/GUI/Panels/MainPanel.xaml.cs
@@ -1034,7 +1034,7 @@ namespace HaRepacker.GUI.Panels
                     CheckImageNodeRecursively(child);
             }
             WzNode hash = WzNode.GetChildNode(node, "_hash");
-            if (hash != null) { hash.Remove(); }
+            if (hash != null) { hash.DeleteWzNode(); }
         }
 
 


### PR DESCRIPTION
In the original version before modification, the functionality merely involved removing from TreeList, without actually altering the img.