### PR TITLE
Fix canvas read write

### DIFF
--- a/MapleLib/WzLib/WzProperties/WzCanvasProperty.cs
+++ b/MapleLib/WzLib/WzProperties/WzCanvasProperty.cs
@@ -171,7 +171,7 @@ namespace MapleLib.WzLib.WzProperties
             writer.WriteCompressedInt(PngProperty.Width);
             writer.WriteCompressedInt(PngProperty.Height);
             writer.WriteCompressedInt(PngProperty.Format);
-            writer.Write((byte)PngProperty.Format2);
+            writer.WriteCompressedInt(PngProperty.Format2);
             writer.Write((Int32)0);
 
             // Write image

--- a/MapleLib/WzLib/WzProperties/WzPngProperty.cs
+++ b/MapleLib/WzLib/WzProperties/WzPngProperty.cs
@@ -200,7 +200,7 @@ namespace MapleLib.WzLib.WzProperties
             width = reader.ReadCompressedInt();
             height = reader.ReadCompressedInt();
             format = reader.ReadCompressedInt();
-            format2 = reader.ReadByte();
+            format2 = reader.ReadCompressedInt();
             reader.BaseStream.Position += 4;
             offs = reader.BaseStream.Position;
             int len = reader.ReadInt32() - 1;


### PR DESCRIPTION
`format2` which is actually `mag level` is suppose to be a compressed int.

Fix initially from `fabwarlock` on the HeavenMS Discord but I've confirmed it with other sources that this is correct.

Can cause issues like
![example](https://cdn.discordapp.com/attachments/1070520624281296956/1145977201993457736/image.png)
when editing skins in Character.wz