### PR TITLE
fix loading v83 files

### DIFF
--- a/MapleLib/WzLib/WzDirectory.cs
+++ b/MapleLib/WzLib/WzDirectory.cs
@@ -271,11 +271,8 @@ namespace MapleLib.WzLib
 
             foreach (WzDirectory subdir in subDirs)
             {
-                if (subdir.Checksum != 0)
-                {
-                    reader.BaseStream.Position = subdir.offset;
-                    subdir.ParseDirectory();
-                }
+                reader.BaseStream.Position = subdir.offset;
+                subdir.ParseDirectory();
             }
         }
 


### PR DESCRIPTION
tbh idk why there's a check here but disabling it allows v83 files to function correctly in the editor again. This makes it possible to load the maps in the map selector. Previously the map selector would show the map names but not allow you to load them.