### PR TITLE
Properly remove rope from boarditems

### DIFF
--- a/HaCreator/MapEditor/Instance/Shapes/Rope.cs
+++ b/HaCreator/MapEditor/Instance/Shapes/Rope.cs
@@ -48,6 +48,7 @@ namespace HaCreator.MapEditor.Instance.Shapes
                 board.BoardItems.RopeAnchors.Remove(firstAnchor);
                 board.BoardItems.RopeAnchors.Remove(secondAnchor);
                 board.BoardItems.RopeLines.Remove(line);
+                board.BoardItems.Ropes.Remove(this);
                 if (undoPipe != null)
                 {
                     undoPipe.Add(UndoRedoManager.RopeRemoved(this));


### PR DESCRIPTION
I tested multiple versions of harepacker res & an old version from haha labeled 2.1.1, all failed to delete ropes properly. This seems to fix it. Fixes #49 

Not sure why ropes have an extra list but they do, and its used for saving.


Also I would have pushed to staging but submodules are the worst thing to ever exist and I can't compile that branch. Plus trying to pull that branch broke my local git repo and ended in my uncommitted changes being completely deleted. But hey at least spine-runtimes submodule on master works fine for me.