### PR TITLE
Fixes and Improvements

### DIFF
--- a/HaRepacker/GUI/CustomWZEncryptionInputBox.cs
+++ b/HaRepacker/GUI/CustomWZEncryptionInputBox.cs
@@ -247,9 +247,14 @@ namespace HaRepacker.GUI
                     }
                 }
             }
-
-            var currentLoadedKey = WzKeyGenerator.GenerateWzKey(Program.ConfigurationManager.GetCusomWzIVEncryption(), MapleCryptoConstants.UserKey_WzLib); // from ApplicationSettings.txt
-            var matchedIndex = Program.ConfigurationManager.CustomKeys.FindIndex(k => k.WzKey == currentLoadedKey); // find the matched one
+            
+            // load the custom user key from ApplicationSettings.txt
+            var iv = Program.ConfigurationManager.GetCusomWzIVEncryption();
+            Program.ConfigurationManager.SetCustomWzUserKeyFromConfig();
+            var currentLoadedKey = WzKeyGenerator.GenerateWzKey(iv, MapleCryptoConstants.UserKey_WzLib);
+            
+            // find the matched one
+            var matchedIndex = Program.ConfigurationManager.CustomKeys.FindIndex(k => k.WzKey == currentLoadedKey);
 
             if (matchedIndex != -1) {
                 nameBox.SelectedIndex = matchedIndex;

--- a/HaRepacker/GUI/CustomWZEncryptionInputBox.cs
+++ b/HaRepacker/GUI/CustomWZEncryptionInputBox.cs
@@ -86,26 +86,10 @@ namespace HaRepacker.GUI
             }
             else
             {
-                int i = 0;
-                foreach (string byte_ in splitBytes)
-                {
-                    switch (i)
-                    {
-                        case 0:
-                            textBox_byte0.Text = byte_;
-                            break;
-                        case 1:
-                            textBox_byte1.Text = byte_;
-                            break;
-                        case 2:
-                            textBox_byte2.Text = byte_;
-                            break;
-                        case 3:
-                            textBox_byte3.Text = byte_;
-                            break;
-                    }
-                    i++;
-                }
+                textBox_byte0.Text = splitBytes[0];
+                textBox_byte1.Text = splitBytes[1];
+                textBox_byte2.Text = splitBytes[2];
+                textBox_byte3.Text = splitBytes[3];
             }
 
             // AES User key
@@ -141,110 +125,7 @@ namespace HaRepacker.GUI
                 }
                 else
                 {
-                    int i = 0;
-                    foreach (string byte_ in splitAESKeyBytes)
-                    {
-                        switch (i)
-                        {
-                            case 0:
-                                textBox_AESUserKey1.Text = byte_;
-                                break;
-                            case 1:
-                                textBox_AESUserKey2.Text = byte_;
-                                break;
-                            case 2:
-                                textBox_AESUserKey3.Text = byte_;
-                                break;
-                            case 3:
-                                textBox_AESUserKey4.Text = byte_;
-                                break;
-                            case 4:
-                                textBox_AESUserKey5.Text = byte_;
-                                break;
-                            case 5:
-                                textBox_AESUserKey6.Text = byte_;
-                                break;
-                            case 6:
-                                textBox_AESUserKey7.Text = byte_;
-                                break;
-                            case 7:
-                                textBox_AESUserKey8.Text = byte_;
-                                break;
-                            case 8:
-                                textBox_AESUserKey9.Text = byte_;
-                                break;
-                            case 9:
-                                textBox_AESUserKey10.Text = byte_;
-                                break;
-                            case 10:
-                                textBox_AESUserKey11.Text = byte_;
-                                break;
-                            case 11:
-                                textBox_AESUserKey12.Text = byte_;
-                                break;
-                            case 12:
-                                textBox_AESUserKey13.Text = byte_;
-                                break;
-                            case 13:
-                                textBox_AESUserKey14.Text = byte_;
-                                break;
-                            case 14:
-                                textBox_AESUserKey15.Text = byte_;
-                                break;
-                            case 15:
-                                textBox_AESUserKey16.Text = byte_;
-                                break;
-                            case 16:
-                                textBox_AESUserKey17.Text = byte_;
-                                break;
-                            case 17:
-                                textBox_AESUserKey18.Text = byte_;
-                                break;
-                            case 18:
-                                textBox_AESUserKey19.Text = byte_;
-                                break;
-                            case 19:
-                                textBox_AESUserKey20.Text = byte_;
-                                break;
-                            case 20:
-                                textBox_AESUserKey21.Text = byte_;
-                                break;
-                            case 21:
-                                textBox_AESUserKey22.Text = byte_;
-                                break;
-                            case 22:
-                                textBox_AESUserKey23.Text = byte_;
-                                break;
-                            case 23:
-                                textBox_AESUserKey24.Text = byte_;
-                                break;
-                            case 24:
-                                textBox_AESUserKey25.Text = byte_;
-                                break;
-                            case 25:
-                                textBox_AESUserKey26.Text = byte_;
-                                break;
-                            case 26:
-                                textBox_AESUserKey27.Text = byte_;
-                                break;
-                            case 27:
-                                textBox_AESUserKey28.Text = byte_;
-                                break;
-                            case 28:
-                                textBox_AESUserKey29.Text = byte_;
-                                break;
-                            case 29:
-                                textBox_AESUserKey30.Text = byte_;
-                                break;
-                            case 30:
-                                textBox_AESUserKey31.Text = byte_;
-                                break;
-                            case 31:
-                                textBox_AESUserKey32.Text = byte_;
-                                break;
-                        }
-                        i++;
-                    }
+                   UserKey2TextBoxes(splitAESKeyBytes);
                 }
             }
             
@@ -297,38 +178,7 @@ namespace HaRepacker.GUI
 
             // AES User Key
             var aesUserKey = _currentSelectedEncryptionKey.AesUserKey.Split(' ');
-            textBox_AESUserKey1.Text = aesUserKey[0];
-            textBox_AESUserKey2.Text = aesUserKey[1];
-            textBox_AESUserKey3.Text = aesUserKey[2];
-            textBox_AESUserKey4.Text = aesUserKey[3];
-            textBox_AESUserKey5.Text = aesUserKey[4];
-            textBox_AESUserKey6.Text = aesUserKey[5];
-            textBox_AESUserKey7.Text = aesUserKey[6];
-            textBox_AESUserKey8.Text = aesUserKey[7];
-            textBox_AESUserKey9.Text = aesUserKey[8];
-            textBox_AESUserKey10.Text = aesUserKey[9];
-            textBox_AESUserKey11.Text = aesUserKey[10];
-            textBox_AESUserKey12.Text = aesUserKey[11];
-            textBox_AESUserKey13.Text = aesUserKey[12];
-            textBox_AESUserKey14.Text = aesUserKey[13];
-            textBox_AESUserKey15.Text = aesUserKey[14];
-            textBox_AESUserKey16.Text = aesUserKey[15];
-            textBox_AESUserKey17.Text = aesUserKey[16];
-            textBox_AESUserKey18.Text = aesUserKey[17];
-            textBox_AESUserKey19.Text = aesUserKey[18];
-            textBox_AESUserKey20.Text = aesUserKey[19];
-            textBox_AESUserKey21.Text = aesUserKey[20];
-            textBox_AESUserKey22.Text = aesUserKey[21];
-            textBox_AESUserKey23.Text = aesUserKey[22];
-            textBox_AESUserKey24.Text = aesUserKey[23];
-            textBox_AESUserKey25.Text = aesUserKey[24];
-            textBox_AESUserKey26.Text = aesUserKey[25];
-            textBox_AESUserKey27.Text = aesUserKey[26];
-            textBox_AESUserKey28.Text = aesUserKey[27];
-            textBox_AESUserKey29.Text = aesUserKey[28];
-            textBox_AESUserKey30.Text = aesUserKey[29];
-            textBox_AESUserKey31.Text = aesUserKey[30];
-            textBox_AESUserKey32.Text = aesUserKey[31];
+            UserKey2TextBoxes(aesUserKey);
         }
 
         private void createButton_Click(object sender, EventArgs e) {
@@ -380,78 +230,37 @@ namespace HaRepacker.GUI
             }
 
             // IV 
-            string strByte0 = textBox_byte0.Text;
-            string strByte1 = textBox_byte1.Text;
-            string strByte2 = textBox_byte2.Text;
-            string strByte3 = textBox_byte3.Text;
+            string[] ivBytes = new string[4]
+            {
+                textBox_byte0.Text,
+                textBox_byte1.Text,
+                textBox_byte2.Text,
+                textBox_byte3.Text
+            };
 
-            if (!CheckHexDigits(strByte0) || !CheckHexDigits(strByte1) || !CheckHexDigits(strByte2) || !CheckHexDigits(strByte3))
+            if (!CheckHexDigits(ivBytes[0]) || !CheckHexDigits(ivBytes[1]) || !CheckHexDigits(ivBytes[2]) || !CheckHexDigits(ivBytes[3]))
             {
                 MessageBox.Show("Wrong format for AES IV. Please check the input bytes.", "Error");
                 return;
             }
 
             // AES User Key
-            string strUserKey1 = textBox_AESUserKey1.Text;
-            string strUserKey2 = textBox_AESUserKey2.Text;
-            string strUserKey3 = textBox_AESUserKey3.Text;
-            string strUserKey4 = textBox_AESUserKey4.Text;
-            string strUserKey5 = textBox_AESUserKey5.Text;
-            string strUserKey6 = textBox_AESUserKey6.Text;
-            string strUserKey7 = textBox_AESUserKey7.Text;
-            string strUserKey8 = textBox_AESUserKey8.Text;
-            string strUserKey9 = textBox_AESUserKey9.Text;
-            string strUserKey10 = textBox_AESUserKey10.Text;
-            string strUserKey11 = textBox_AESUserKey11.Text;
-            string strUserKey12 = textBox_AESUserKey12.Text;
-            string strUserKey13 = textBox_AESUserKey13.Text;
-            string strUserKey14 = textBox_AESUserKey14.Text;
-            string strUserKey15 = textBox_AESUserKey15.Text;
-            string strUserKey16 = textBox_AESUserKey16.Text;
-            string strUserKey17 = textBox_AESUserKey17.Text;
-            string strUserKey18 = textBox_AESUserKey18.Text;
-            string strUserKey19 = textBox_AESUserKey19.Text;
-            string strUserKey20 = textBox_AESUserKey20.Text;
-            string strUserKey21 = textBox_AESUserKey21.Text;
-            string strUserKey22 = textBox_AESUserKey22.Text;
-            string strUserKey23 = textBox_AESUserKey23.Text;
-            string strUserKey24 = textBox_AESUserKey24.Text;
-            string strUserKey25 = textBox_AESUserKey25.Text;
-            string strUserKey26 = textBox_AESUserKey26.Text;
-            string strUserKey27 = textBox_AESUserKey27.Text;
-            string strUserKey28 = textBox_AESUserKey28.Text;
-            string strUserKey29 = textBox_AESUserKey29.Text;
-            string strUserKey30 = textBox_AESUserKey30.Text;
-            string strUserKey31 = textBox_AESUserKey31.Text;
-            string strUserKey32 = textBox_AESUserKey32.Text;
+            // AES User Key (using the new TextBoxes2UserKey method)
+            string[] userKeys = TextBoxes2UserKey();
 
-            if (
-                !CheckHexDigits(strUserKey1) || !CheckHexDigits(strUserKey2) || !CheckHexDigits(strUserKey3) || !CheckHexDigits(strUserKey4) || !CheckHexDigits(strUserKey5) || !CheckHexDigits(strUserKey6) || !CheckHexDigits(strUserKey7) || !CheckHexDigits(strUserKey8) || !CheckHexDigits(strUserKey9) || !CheckHexDigits(strUserKey10) ||
-                !CheckHexDigits(strUserKey11) || !CheckHexDigits(strUserKey12) || !CheckHexDigits(strUserKey13) || !CheckHexDigits(strUserKey14) || !CheckHexDigits(strUserKey15) || !CheckHexDigits(strUserKey16) || !CheckHexDigits(strUserKey17) || !CheckHexDigits(strUserKey18) || !CheckHexDigits(strUserKey19) || !CheckHexDigits(strUserKey20) ||
-                !CheckHexDigits(strUserKey21) || !CheckHexDigits(strUserKey22) || !CheckHexDigits(strUserKey23) || !CheckHexDigits(strUserKey24) || !CheckHexDigits(strUserKey25) || !CheckHexDigits(strUserKey26) || !CheckHexDigits(strUserKey27) || !CheckHexDigits(strUserKey28) || !CheckHexDigits(strUserKey29) || !CheckHexDigits(strUserKey30) ||
-                !CheckHexDigits(strUserKey31) || !CheckHexDigits(strUserKey32))
+            for (int i = 0; i < userKeys.Length; i++)
             {
-                MessageBox.Show("Wrong format for AES User Key. Please check the input bytes.", "Error");
-                return;
+                if (!CheckHexDigits(userKeys[i]))
+                {
+                    MessageBox.Show("Wrong format for AES User Key. Please check the input bytes.", "Error");
+                    return;
+                }
             }
 
             // Save
-            Program.ConfigurationManager.ApplicationSettings.MapleVersion_CustomEncryptionBytes =
-                string.Format("{0} {1} {2} {3}",
-                strByte0,
-                strByte1,
-                strByte2,
-                strByte3);
-
-            Program.ConfigurationManager.ApplicationSettings.MapleVersion_CustomAESUserKey =
-                string.Format("{0} {1} {2} {3} {4} {5} {6} {7} {8} {9} {10} {11} {12} {13} {14} {15} {16} {17} {18} {19} {20} {21} {22} {23} {24} {25} {26} {27} {28} {29} {30} {31}",
-                strUserKey1, strUserKey2, strUserKey3, strUserKey4, strUserKey5, strUserKey6, strUserKey7, strUserKey8, strUserKey9, strUserKey10,
-                strUserKey11, strUserKey12, strUserKey13, strUserKey14, strUserKey15, strUserKey16, strUserKey17, strUserKey18, strUserKey19, strUserKey20,
-                strUserKey21, strUserKey22, strUserKey23, strUserKey24, strUserKey25, strUserKey26, strUserKey27, strUserKey28, strUserKey29, strUserKey30,
-                strUserKey31, strUserKey32
-                );
-
             Program.ConfigurationManager.ApplicationSettings.MapleVersion_CustomEncryptionName = nameBox.Text;
+            Program.ConfigurationManager.ApplicationSettings.MapleVersion_CustomEncryptionBytes = string.Join(" ", ivBytes);
+            Program.ConfigurationManager.ApplicationSettings.MapleVersion_CustomAESUserKey = string.Join(" ", userKeys);
 
             // Set the UserKey in memory.
             Program.ConfigurationManager.SetCustomWzUserKeyFromConfig();
@@ -553,6 +362,82 @@ namespace HaRepacker.GUI
             textBox_AESUserKey30.Text = HexTool.ToString(AESUserKey[29 * 4]);
             textBox_AESUserKey31.Text = HexTool.ToString(AESUserKey[30 * 4]);
             textBox_AESUserKey32.Text = HexTool.ToString(AESUserKey[31 * 4]);
+        }
+
+        private void UserKey2TextBoxes(string[] aesUserKey)
+        {
+            textBox_AESUserKey1.Text = aesUserKey[0];
+            textBox_AESUserKey2.Text = aesUserKey[1];
+            textBox_AESUserKey3.Text = aesUserKey[2];
+            textBox_AESUserKey4.Text = aesUserKey[3];
+            textBox_AESUserKey5.Text = aesUserKey[4];
+            textBox_AESUserKey6.Text = aesUserKey[5];
+            textBox_AESUserKey7.Text = aesUserKey[6];
+            textBox_AESUserKey8.Text = aesUserKey[7];
+            textBox_AESUserKey9.Text = aesUserKey[8];
+            textBox_AESUserKey10.Text = aesUserKey[9];
+            textBox_AESUserKey11.Text = aesUserKey[10];
+            textBox_AESUserKey12.Text = aesUserKey[11];
+            textBox_AESUserKey13.Text = aesUserKey[12];
+            textBox_AESUserKey14.Text = aesUserKey[13];
+            textBox_AESUserKey15.Text = aesUserKey[14];
+            textBox_AESUserKey16.Text = aesUserKey[15];
+            textBox_AESUserKey17.Text = aesUserKey[16];
+            textBox_AESUserKey18.Text = aesUserKey[17];
+            textBox_AESUserKey19.Text = aesUserKey[18];
+            textBox_AESUserKey20.Text = aesUserKey[19];
+            textBox_AESUserKey21.Text = aesUserKey[20];
+            textBox_AESUserKey22.Text = aesUserKey[21];
+            textBox_AESUserKey23.Text = aesUserKey[22];
+            textBox_AESUserKey24.Text = aesUserKey[23];
+            textBox_AESUserKey25.Text = aesUserKey[24];
+            textBox_AESUserKey26.Text = aesUserKey[25];
+            textBox_AESUserKey27.Text = aesUserKey[26];
+            textBox_AESUserKey28.Text = aesUserKey[27];
+            textBox_AESUserKey29.Text = aesUserKey[28];
+            textBox_AESUserKey30.Text = aesUserKey[29];
+            textBox_AESUserKey31.Text = aesUserKey[30];
+            textBox_AESUserKey32.Text = aesUserKey[31];
+        }
+        
+        private string[] TextBoxes2UserKey()
+        {
+            string[] aesUserKey = new string[32];
+    
+            aesUserKey[0] = textBox_AESUserKey1.Text;
+            aesUserKey[1] = textBox_AESUserKey2.Text;
+            aesUserKey[2] = textBox_AESUserKey3.Text;
+            aesUserKey[3] = textBox_AESUserKey4.Text;
+            aesUserKey[4] = textBox_AESUserKey5.Text;
+            aesUserKey[5] = textBox_AESUserKey6.Text;
+            aesUserKey[6] = textBox_AESUserKey7.Text;
+            aesUserKey[7] = textBox_AESUserKey8.Text;
+            aesUserKey[8] = textBox_AESUserKey9.Text;
+            aesUserKey[9] = textBox_AESUserKey10.Text;
+            aesUserKey[10] = textBox_AESUserKey11.Text;
+            aesUserKey[11] = textBox_AESUserKey12.Text;
+            aesUserKey[12] = textBox_AESUserKey13.Text;
+            aesUserKey[13] = textBox_AESUserKey14.Text;
+            aesUserKey[14] = textBox_AESUserKey15.Text;
+            aesUserKey[15] = textBox_AESUserKey16.Text;
+            aesUserKey[16] = textBox_AESUserKey17.Text;
+            aesUserKey[17] = textBox_AESUserKey18.Text;
+            aesUserKey[18] = textBox_AESUserKey19.Text;
+            aesUserKey[19] = textBox_AESUserKey20.Text;
+            aesUserKey[20] = textBox_AESUserKey21.Text;
+            aesUserKey[21] = textBox_AESUserKey22.Text;
+            aesUserKey[22] = textBox_AESUserKey23.Text;
+            aesUserKey[23] = textBox_AESUserKey24.Text;
+            aesUserKey[24] = textBox_AESUserKey25.Text;
+            aesUserKey[25] = textBox_AESUserKey26.Text;
+            aesUserKey[26] = textBox_AESUserKey27.Text;
+            aesUserKey[27] = textBox_AESUserKey28.Text;
+            aesUserKey[28] = textBox_AESUserKey29.Text;
+            aesUserKey[29] = textBox_AESUserKey30.Text;
+            aesUserKey[30] = textBox_AESUserKey31.Text;
+            aesUserKey[31] = textBox_AESUserKey32.Text;
+
+            return aesUserKey;
         }
 
         /// <summary>

--- a/HaRepacker/GUI/NewForm.cs
+++ b/HaRepacker/GUI/NewForm.cs
@@ -16,15 +16,27 @@ namespace HaRepacker.GUI
 {
     public partial class NewForm : Form
     {
-        private MainPanel panel;
+        private readonly MainPanel _mainPanel;
 
-        private bool bIsLoading;
+        private bool bIsLoaded = false;
+
+        private int defaultVersionIndex;
+
         public NewForm(MainPanel panel)
         {
-            this.panel = panel;
+            this._mainPanel = panel;
             InitializeComponent();
 
-            Load += NewForm_Load;
+            MainForm.AddWzEncryptionTypesToComboBox(encryptionBox);
+            SetWzEncryptionBoxSelectionByWzMapleVersion();
+            defaultVersionIndex = encryptionBox.SelectedIndex;
+
+            versionBox.Value = 1;
+            
+            // change back to default
+            Closed += (sender, args) => encryptionBox.SelectedIndex = defaultVersionIndex;
+
+            bIsLoaded = true;
         }
 
         /// <summary>
@@ -41,23 +53,8 @@ namespace HaRepacker.GUI
                 Close(); // exit window
                 return true;
             }
+
             return base.ProcessCmdKey(ref msg, keyData);
-        }
-
-
-        private void NewForm_Load(object sender, EventArgs e)
-        {
-            bIsLoading = true;
-            try
-            {
-                MainForm.AddWzEncryptionTypesToComboBox(encryptionBox);
-
-                encryptionBox.SelectedIndex = MainForm.GetIndexByWzMapleVersion(Program.ConfigurationManager.ApplicationSettings.MapleVersion, true);
-                versionBox.Value = 1;
-            } finally
-            {
-                bIsLoading = false;
-            }
         }
 
         /// <summary>
@@ -67,39 +64,56 @@ namespace HaRepacker.GUI
         /// <param name="e"></param>
         private void EncryptionBox_SelectionChanged(object sender, EventArgs e)
         {
-            if (bIsLoading)
+            if (!bIsLoaded)
                 return;
 
             EncryptionKey selectedEncryption = (EncryptionKey)encryptionBox.SelectedItem;
             if (selectedEncryption.MapleVersion == WzMapleVersion.CUSTOM)
             {
                 Program.ConfigurationManager.SetCustomWzUserKeyFromConfig();
-            } else
+            }
+            else
             {
                 MapleCryptoConstants.UserKey_WzLib = MapleCryptoConstants.MAPLESTORY_USERKEY_DEFAULT.ToArray();
             }
         }
 
+        private void SetWzEncryptionBoxSelectionByWzMapleVersion()
+        {
+            var wzMapleVersion = Program.ConfigurationManager.ApplicationSettings.MapleVersion;
+            encryptionBox.SelectedIndex = MainForm.GetIndexByWzMapleVersion(wzMapleVersion, true);
+            if (wzMapleVersion == WzMapleVersion.CUSTOM)
+            {
+                Program.ConfigurationManager.SetCustomWzUserKeyFromConfig();
+            }
+        }
+
         /// <summary>
-        /// 
+        /// Selecting list WZ checkbox
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
         private void Listwz_CheckedChanged(object sender, EventArgs e)
         {
-            copyrightBox.Enabled = true;
-            versionBox.Enabled = true;
+            if (listBox.Checked)
+            {
+                copyrightBox.Enabled = true;
+                versionBox.Enabled = true;
+            }
         }
 
         /// <summary>
-        /// 
+        /// Selecting hotfix data WZ checkbox
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
         private void DataWZ_CheckedChanged(object sender, EventArgs e)
         {
-            copyrightBox.Enabled = false;
-            versionBox.Enabled = false;
+            if (radioButton_hotfix.Checked)
+            {
+                copyrightBox.Enabled = false;
+                versionBox.Enabled = false;
+            }
         }
 
         /// <summary>
@@ -109,11 +123,11 @@ namespace HaRepacker.GUI
         /// <param name="e"></param>
         private void regBox_CheckedChanged(object sender, EventArgs e)
         {
-            copyrightBox.Enabled = regBox.Checked;
-            versionBox.Enabled = regBox.Checked;
-
-            copyrightBox.Enabled = true;
-            versionBox.Enabled = true;
+            if (regBox.Checked)
+            {
+                copyrightBox.Enabled = true;
+                versionBox.Enabled = true;
+            }
         }
 
         private void cancelButton_Click(object sender, EventArgs e)
@@ -123,29 +137,31 @@ namespace HaRepacker.GUI
 
         private void okButton_Click(object sender, EventArgs e)
         {
-            string name = nameBox.Text;
+            string name = nameBox.Text.Trim();
+            WzMapleVersion wzMapleVersionSelected = ((EncryptionKey)encryptionBox.SelectedItem).MapleVersion; // new encryption selected
 
             if (regBox.Checked)
             {
-                WzFile file = new WzFile((short)versionBox.Value, (WzMapleVersion)encryptionBox.SelectedIndex);
+                WzFile file = new WzFile((short)versionBox.Value, wzMapleVersionSelected);
                 file.Header.Copyright = copyrightBox.Text;
                 file.Header.RecalculateFileStart();
                 file.Name = name + ".wz";
                 file.WzDirectory.Name = name + ".wz";
-                panel.DataTree.Nodes.Add(new WzNode(file));
+                _mainPanel.DataTree.Nodes.Add(new WzNode(file));
             }
-            else if (listBox.Checked == true) 
+            else if (listBox.Checked == true)
             {
-                new ListEditor(null, (WzMapleVersion)encryptionBox.SelectedIndex).Show();
+                new ListEditor(null, wzMapleVersionSelected).Show();
             }
             else if (radioButton_hotfix.Checked == true)
             {
                 WzImage img = new WzImage(name + ".wz");
                 img.MarkWzImageAsParsed();
-     
+
                 WzNode node = new WzNode(img);
-                panel.DataTree.Nodes.Add(node);
+                _mainPanel.DataTree.Nodes.Add(node);
             }
+
             Close();
         }
     }

--- a/HaRepacker/GUI/NewForm.cs
+++ b/HaRepacker/GUI/NewForm.cs
@@ -8,6 +8,7 @@ using System;
 using System.Windows.Forms;
 using MapleLib.WzLib;
 using HaRepacker.GUI.Panels;
+using MapleLib.Configuration;
 using MapleLib.MapleCryptoLib;
 using System.Linq;
 
@@ -69,12 +70,10 @@ namespace HaRepacker.GUI
             if (bIsLoading)
                 return;
 
-            int selectedIndex = encryptionBox.SelectedIndex;
-            WzMapleVersion wzMapleVersion = MainForm.GetWzMapleVersionByWzEncryptionBoxSelection(selectedIndex);
-            if (wzMapleVersion == WzMapleVersion.CUSTOM)
+            EncryptionKey selectedEncryption = (EncryptionKey)encryptionBox.SelectedItem;
+            if (selectedEncryption.MapleVersion == WzMapleVersion.CUSTOM)
             {
-                CustomWZEncryptionInputBox customWzInputBox = new CustomWZEncryptionInputBox();
-                customWzInputBox.ShowDialog();
+                Program.ConfigurationManager.SetCustomWzUserKeyFromConfig();
             } else
             {
                 MapleCryptoConstants.UserKey_WzLib = MapleCryptoConstants.MAPLESTORY_USERKEY_DEFAULT.ToArray();

--- a/HaRepacker/GUI/SaveForm.cs
+++ b/HaRepacker/GUI/SaveForm.cs
@@ -11,6 +11,7 @@ using System.IO;
 using MapleLib.WzLib.Util;
 using System.Diagnostics;
 using HaRepacker.GUI.Panels;
+using MapleLib.Configuration;
 using MapleLib.MapleCryptoLib;
 using System.Linq;
 
@@ -118,12 +119,10 @@ namespace HaRepacker.GUI
             if (bIsLoading)
                 return;
 
-            int selectedIndex = encryptionBox.SelectedIndex;
-            WzMapleVersion wzMapleVersion = MainForm.GetWzMapleVersionByWzEncryptionBoxSelection(selectedIndex);
-            if (wzMapleVersion == WzMapleVersion.CUSTOM)
+            EncryptionKey selectedEncryption = (EncryptionKey)encryptionBox.SelectedItem;
+            if (selectedEncryption.MapleVersion == WzMapleVersion.CUSTOM)
             {
-                CustomWZEncryptionInputBox customWzInputBox = new CustomWZEncryptionInputBox();
-                customWzInputBox.ShowDialog();
+                Program.ConfigurationManager.SetCustomWzUserKeyFromConfig();
             }
             else
             {

--- a/HaRepacker/GUI/SaveForm.cs
+++ b/HaRepacker/GUI/SaveForm.cs
@@ -28,9 +28,9 @@ namespace HaRepacker.GUI
 
         public string path;
         private readonly MainPanel _mainPanel;
+        private int defaultVersionIndex;
 
-
-        private bool bIsLoading = false;
+        private bool bIsLoaded = false;
 
         /// <summary>
         /// Constructor
@@ -44,51 +44,34 @@ namespace HaRepacker.GUI
             MainForm.AddWzEncryptionTypesToComboBox(encryptionBox);
 
             this.wzNode = wzNode;
-            if (wzNode.Tag is WzImage) // Data.wz hotfix file
+            if (wzNode.Tag is WzImage image) // Data.wz hotfix file
             {
-                this.wzImg = (WzImage)wzNode.Tag;
+                this.wzImg = image;
                 this.IsRegularWzFile = false;
+
+                // Data.wz uses BMS encryption... no sepcific version indicated
+                SetWzEncryptionBoxSelectionByWzMapleVersion(WzMapleVersion.BMS);
 
                 versionBox.Enabled = false; // disable, not necessary
                 checkBox_64BitFile.Enabled = false; // disable, not necessary
-
             }
             else
             {
                 this.wzf = (WzFile)wzNode.Tag;
                 this.IsRegularWzFile = true;
+                
+                SetWzEncryptionBoxSelectionByWzMapleVersion(wzf.MapleVersion);
+
+                versionBox.Value = wzf.Version;
+                versionBox.Enabled = wzf.Is64BitWzFile ? false : true; // disable checkbox if its checked as 64-bit, since the version will always be 777
+                checkBox_64BitFile.Checked = wzf.Is64BitWzFile;
             }
             this._mainPanel = panel;
-        }
-
-        /// <summary>
-        /// On loading
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void SaveForm_Load(object sender, EventArgs e)
-        {
-            bIsLoading = true;
-
-            try
-            {
-                if (this.IsRegularWzFile)
-                {
-                    encryptionBox.SelectedIndex = MainForm.GetIndexByWzMapleVersion(wzf.MapleVersion);
-                    versionBox.Value = wzf.Version;
-
-                    checkBox_64BitFile.Checked = wzf.Is64BitWzFile;
-                    versionBox.Enabled = wzf.Is64BitWzFile ? false : true; // disable checkbox if its checked as 64-bit, since the version will always be 777
-                }
-                else
-                { // Data.wz uses BMS encryption... no sepcific version indicated
-                    encryptionBox.SelectedIndex = MainForm.GetIndexByWzMapleVersion(WzMapleVersion.BMS);
-                }
-            }
-            finally
-            {
-                bIsLoading = false;
-            }
+            
+            defaultVersionIndex = encryptionBox.SelectedIndex;
+            Closed += (sender, args) => encryptionBox.SelectedIndex = defaultVersionIndex;
+            
+            bIsLoaded = true;
         }
 
         /// <summary>
@@ -116,7 +99,7 @@ namespace HaRepacker.GUI
         /// <param name="e"></param>
         private void encryptionBox_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (bIsLoading)
+            if (!bIsLoaded)
                 return;
 
             EncryptionKey selectedEncryption = (EncryptionKey)encryptionBox.SelectedItem;
@@ -127,6 +110,15 @@ namespace HaRepacker.GUI
             else
             {
                 MapleCryptoConstants.UserKey_WzLib = MapleCryptoConstants.MAPLESTORY_USERKEY_DEFAULT.ToArray();
+            }
+        }
+        
+        private void SetWzEncryptionBoxSelectionByWzMapleVersion(WzMapleVersion versionSelected)
+        {
+            encryptionBox.SelectedIndex = MainForm.GetIndexByWzMapleVersion(versionSelected);
+            if (versionSelected == WzMapleVersion.CUSTOM)
+            {
+                Program.ConfigurationManager.SetCustomWzUserKeyFromConfig();
             }
         }
 
@@ -155,7 +147,7 @@ namespace HaRepacker.GUI
                     return;
 
                 bool bSaveAs64BitWzFile = checkBox_64BitFile.Checked; // no version number
-                WzMapleVersion wzMapleVersionSelected = MainForm.GetWzMapleVersionByWzEncryptionBoxSelection(encryptionBox.SelectedIndex); // new encryption selected
+                WzMapleVersion wzMapleVersionSelected = ((EncryptionKey)encryptionBox.SelectedItem).MapleVersion; // new encryption selected
                 if (this.IsRegularWzFile)
                 {
 
@@ -259,11 +251,13 @@ namespace HaRepacker.GUI
         /// <param name="e"></param>
         private void checkBox_64BitFile_CheckedChanged(object sender, EventArgs e)
         {
-            if (bIsLoading)
+            if (!bIsLoaded)
                 return;
 
-            CheckBox checkbox_64 = (CheckBox)sender;
-            versionBox.Enabled = checkbox_64.Checked != true; // disable checkbox if its checked as 64-bit, since the version will always be 777
+            if (sender is CheckBox checkbox_64)
+            {
+                versionBox.Enabled = checkbox_64.Checked != true; // disable checkbox if its checked as 64-bit, since the version will always be 777
+            }
         }
     }
 }

--- a/HaRepacker/GUI/SaveForm.designer.cs
+++ b/HaRepacker/GUI/SaveForm.designer.cs
@@ -89,7 +89,6 @@ namespace HaRepacker.GUI
             this.Controls.Add(this.encryptionBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.Name = "SaveForm";
-            this.Load += new System.EventHandler(this.SaveForm_Load);
             this.ResumeLayout(false);
             this.PerformLayout();
 


### PR DESCRIPTION
Hi, I have made some changes and bugfixes since #253, mainly focus on NewForm and SaveForm, as these 2 dialogs were not correctly handling encryptionbox selection changes, which causes creating and saving wz files with wrong encryption.

Here’s how I envision the expected behavior of the encryptionbox in NewForm/SaveForm dialogs. Please share if you have any alternative ideas:
- selecting the "Use custom encryption key" option will no longer trigger the CustomWZEncryptionInputBox dialog
- default encryption aligns with the selection on MainForm's tool strip
- changing encryption correctly and only applies to the WZ file being created/saved
- changing encryption does not affect the current selection on MainForm's tool strip