### PR TITLE
[HaRepacker] Improve sorting

### DIFF
--- a/HaRepacker/Comparer/SemiNumericComparer.cs
+++ b/HaRepacker/Comparer/SemiNumericComparer.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace HaRepacker.Comparer
 {
@@ -16,35 +13,28 @@ namespace HaRepacker.Comparer
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Compare(string s1Text, string s2Text)
         {
-            bool isS1Numeric = IsNumericString(s1Text);
-            bool isS2Numeric = IsNumericString(s2Text);
+            bool isS1Numeric = int.TryParse(s1Text, out int s1val);
+            bool isS2Numeric = int.TryParse(s2Text, out int s2val);
 
             if (isS1Numeric && isS2Numeric)
             {
-                int s1val = Convert.ToInt32(s1Text);
-                int s2val = Convert.ToInt32(s2Text);
-
                 if (s1val > s2val)
                     return 1;
-                else if (s1val < s2val)
+                if (s1val < s2val)
                     return -1;
-                else if (s1val == s2val)
+                if (s1val == s2val)
                     return 0;
             }
-            else if (isS1Numeric && !isS2Numeric)
+            else if (isS1Numeric)
+            {
                 return -1;
-            else if (!isS1Numeric && isS2Numeric)
+            }
+            else if (isS2Numeric)
+            {
                 return 1;
+            }
 
-            return string.Compare(s1Text, s2Text, true);
-        }
-
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsNumericString(string value)
-        {
-            int parseInt = 0;
-            return Int32.TryParse(value, out parseInt);
+            return string.Compare(s1Text, s2Text, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/HaRepacker/Comparer/TreeViewNodeSorter.cs
+++ b/HaRepacker/Comparer/TreeViewNodeSorter.cs
@@ -7,7 +7,7 @@ namespace HaRepacker.Comparer
 {
     public class TreeViewNodeSorter : IComparer
     {
-        private readonly TreeNode startNode;
+        private readonly TreeNode _startNode;
 
         /// <summary>
         /// Constructor
@@ -15,53 +15,46 @@ namespace HaRepacker.Comparer
         /// <param name="startNode">The starting node to sort from. If this is null, everything will be sorted.</param>
         public TreeViewNodeSorter(TreeNode startNode)
         {
-            this.startNode = startNode;
+            _startNode = startNode;
         }
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int Compare(object s1_, object s2_)
+        public int Compare(object obj1, object obj2)
         {
-            TreeNode t1 = (s1_ as TreeNode);
-            TreeNode t2 = (s2_ as TreeNode);
+            TreeNode node1 = (TreeNode)obj1;
+            TreeNode node2 = (TreeNode)obj2;
 
-            if (startNode != null) {
-                if (t1.Parent != startNode)
-                {
-                    return -1;
-                }
+            if (_startNode != null && node1?.Parent != _startNode)
+            {
+                return -1;
             }
 
-            string s1Text = t1.Text;
-            string s2Text = t2.Text;
+            string text1 = node1?.Text;
+            string text2 = node2?.Text;
 
-            bool isS1Numeric = IsNumeric(s1Text);
-            bool isS2Numeric = IsNumeric(s2Text);
+            bool isS1Numeric = int.TryParse(text1, out int num1);
+            bool isS2Numeric = int.TryParse(text2, out int num2);
 
             if (isS1Numeric && isS2Numeric)
             {
-                int s1val = Convert.ToInt32(s1Text);
-                int s2val = Convert.ToInt32(s2Text);
-
-                if (s1val > s2val)
+                if (num1 > num2)
                     return 1;
-                else if (s1val < s2val)
+                if (num1 < num2)
                     return -1;
-                else if (s1val == s2val)
+                if (num1 == num2)
                     return 0;
-            } else if (isS1Numeric && !isS2Numeric)
+            }
+            else if (isS1Numeric)
+            {
                 return -1;
-            else if (!isS1Numeric && isS2Numeric)
+            }
+            else if (isS2Numeric)
+            {
                 return 1;
+            }
 
-            return string.Compare(s1Text, s2Text, true);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsNumeric(string value)
-        {
-            int parseInt = 0;
-            return Int32.TryParse(value, out parseInt);
+            return string.Compare(text1, text2, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/HaRepacker/GUI/MainForm.cs
+++ b/HaRepacker/GUI/MainForm.cs
@@ -201,10 +201,8 @@ namespace HaRepacker.GUI
         {
             if (Program.ConfigurationManager.UserSettings.Sort || sortFromTheParentNode)
             {
-                parent.TreeView.TreeViewNodeSorter = new TreeViewNodeSorter(sortFromTheParentNode ? parent : null);
-
                 parent.TreeView.BeginUpdate();
-                parent.TreeView.Sort();
+                parent.TreeView.TreeViewNodeSorter = new TreeViewNodeSorter(sortFromTheParentNode ? parent : null);
                 parent.TreeView.EndUpdate();
             }
         }


### PR DESCRIPTION
Sorting is now 4x faster with numeric nodes and 3x faster with string nodes.

- **10k random integer string TreeNode**  
  - **Before:** 33 seconds  
  - **After:** 8 seconds

- **String_000.wz/Consume.img** (26k+ properties) in GMS v253  
  - **Before:** 323 seconds  
  - **After:** 95 seconds

- **QuestData_000.wz** (21k+ images) in GMS v253  
  - **Before:** 127 seconds  
  - **After:** 44 seconds

[The `Sort()` method is automatically called when assigning a new `IComparer`](https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/TreeView.cs,1288).