### PR TITLE
Fix "foramt" typo

### DIFF
--- a/HaRepacker/GUI/MainForm.Designer.cs
+++ b/HaRepacker/GUI/MainForm.Designer.cs
@@ -76,7 +76,7 @@ namespace HaRepacker.GUI
             this.xMLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.rawDataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.imgToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.nXForamtToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.nXFormatToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportDataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.xMLToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.privateServerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -406,7 +406,7 @@ namespace HaRepacker.GUI
             this.xMLToolStripMenuItem,
             this.rawDataToolStripMenuItem,
             this.imgToolStripMenuItem,
-            this.nXForamtToolStripMenuItem});
+            this.nXFormatToolStripMenuItem});
             this.exportFilesToXMLToolStripMenuItem.Image = global::HaRepacker.Properties.Resources.folder_go;
             this.exportFilesToXMLToolStripMenuItem.Name = "exportFilesToXMLToolStripMenuItem";
             resources.ApplyResources(this.exportFilesToXMLToolStripMenuItem, "exportFilesToXMLToolStripMenuItem");
@@ -429,11 +429,11 @@ namespace HaRepacker.GUI
             resources.ApplyResources(this.imgToolStripMenuItem, "imgToolStripMenuItem");
             this.imgToolStripMenuItem.Click += new System.EventHandler(this.imgToolStripMenuItem_Click);
             // 
-            // nXForamtToolStripMenuItem
+            // nXFormatToolStripMenuItem
             // 
-            this.nXForamtToolStripMenuItem.Name = "nXForamtToolStripMenuItem";
-            resources.ApplyResources(this.nXForamtToolStripMenuItem, "nXForamtToolStripMenuItem");
-            this.nXForamtToolStripMenuItem.Click += new System.EventHandler(this.nXForamtToolStripMenuItem_Click);
+            this.nXFormatToolStripMenuItem.Name = "nXFormatToolStripMenuItem";
+            resources.ApplyResources(this.nXFormatToolStripMenuItem, "nXFormatToolStripMenuItem");
+            this.nXFormatToolStripMenuItem.Click += new System.EventHandler(this.nXFormatToolStripMenuItem_Click);
             // 
             // exportDataToolStripMenuItem
             // 
@@ -715,7 +715,7 @@ namespace HaRepacker.GUI
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
-        private System.Windows.Forms.ToolStripMenuItem nXForamtToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem nXFormatToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem_newWzFormat;
         private System.Windows.Forms.ToolStripMenuItem fHMappingToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem renderMapToolStripMenuItem;

--- a/HaRepacker/GUI/MainForm.cs
+++ b/HaRepacker/GUI/MainForm.cs
@@ -2291,7 +2291,7 @@ namespace HaRepacker.GUI
             threadDone = true;
         }
 
-        private void nXForamtToolStripMenuItem_Click(object sender, EventArgs e)
+        private void nXFormatToolStripMenuItem_Click(object sender, EventArgs e)
         {
             OpenFileDialog dialog = new OpenFileDialog()
             {

--- a/HaRepacker/GUI/MainForm.resx
+++ b/HaRepacker/GUI/MainForm.resx
@@ -498,11 +498,11 @@
   <data name="imgToolStripMenuItem.Text" xml:space="preserve">
     <value>IMG</value>
   </data>
-  <data name="nXForamtToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="nXFormatToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>172, 22</value>
   </data>
-  <data name="nXForamtToolStripMenuItem.Text" xml:space="preserve">
-    <value>NXForamt</value>
+  <data name="nXFormatToolStripMenuItem.Text" xml:space="preserve">
+    <value>NXFormat</value>
   </data>
   <data name="exportDataToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>168, 22</value>
@@ -2693,10 +2693,10 @@
   <data name="&gt;&gt;imgToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;nXForamtToolStripMenuItem.Name" xml:space="preserve">
-    <value>nXForamtToolStripMenuItem</value>
+  <data name="&gt;&gt;nXFormatToolStripMenuItem.Name" xml:space="preserve">
+    <value>nXFormatToolStripMenuItem</value>
   </data>
-  <data name="&gt;&gt;nXForamtToolStripMenuItem.Type" xml:space="preserve">
+  <data name="&gt;&gt;nXFormatToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;exportDataToolStripMenuItem.Name" xml:space="preserve">


### PR DESCRIPTION
Fix `foramt` typo: should be `format`.

![image](https://github.com/user-attachments/assets/5ecec3d6-12ef-403f-b69e-a10d722231fb)
