### PR TITLE
[HaCreator] Add gpt-5.4 AI model option

### DIFF
--- a/HaCreator/MapEditor/AI/AISettings.cs
+++ b/HaCreator/MapEditor/AI/AISettings.cs
@@ -127,7 +127,7 @@ namespace HaCreator.MapEditor.AI
             "google/gemini-3.1-pro-preview",
             "google/gemini-3-pro-preview",
             "openai/gpt-5.3-codex",
-            "openai/gpt-5.2",
+            "openai/gpt-5.4",
             "anthropic/claude-sonnet-4.5",
             "anthropic/claude-opus-4.5"
         };
@@ -194,6 +194,7 @@ namespace HaCreator.MapEditor.AI
         {
             DEFAULT_OPENCODE_MODEL,
             "claude-opus-4-5-20251101",
+            "openai/gpt-5.4",
             "openai/gpt-5.3-codex",
             "openai/gpt-5.2"
         };


### PR DESCRIPTION
Add openai/gpt-5.4 to the configured model lists in AISettings for OpenRouter and OpenCode.