### PR TITLE
[HaCreator] Fix OpenCode map tool command capture

### DIFF
--- a/HaCreator/MapEditor/AI/OpenCodeClient.cs
+++ b/HaCreator/MapEditor/AI/OpenCodeClient.cs
@@ -948,146 +948,142 @@ namespace HaCreator.MapEditor.AI
         /// </summary>
         public async Task<string> ProcessInstructionsAsync(string mapContext, string userInstructions)
         {
-            // Ensure OpenCode server is running (auto-start if needed)
             await EnsureServerAsync();
-
-            // Ensure AI Tool Server is running (handles callbacks from OpenCode's server-side tools)
             StartToolServer();
-
-            // Reset query tracker for this conversation
             _calledQueryFunctions.Clear();
+            ClearCollectedCommands();
 
-            // Create a session for this conversation
-            var session = await CreateSessionAsync("map-editor");
-            if (session == null || !session.ContainsKey("id"))
+            var systemPrompt = MapEditorPromptBuilder.LoadSystemPrompt();
+            var userMessage = MapEditorPromptBuilder.BuildUserMessage(mapContext, userInstructions);
+            var tools = MapEditorFunctions.GetToolDefinitions();
+            var localCommands = new List<string>();
+
+            Debug.WriteLine($"[OpenCode] User instructions: {userInstructions}");
+
+            var result = await RunWithToolsAsync(
+                text: userMessage,
+                tools: tools,
+                toolExecutor: (name, args) => ExecuteToolForProcessInstructions(name, args, localCommands),
+                systemPrompt: systemPrompt,
+                sessionTitle: "map-editor",
+                maxIterations: 40,
+                reasoningEffort: defaultReasoningEffort);
+
+            if (!result.Success)
             {
-                throw new Exception("Failed to create OpenCode session");
+                throw new Exception(result.Error ?? "OpenCode RunWithToolsAsync failed.");
             }
 
-            var sessionId = session["id"].ToString();
+            var allCommands = new List<string>();
+            AddUniqueCommands(allCommands, localCommands);
+            AddUniqueCommands(allCommands, GetCollectedCommands());
 
-            try
+            if (allCommands.Count == 0 && result.ToolCallsMade != null)
             {
-                var systemPrompt = MapEditorPromptBuilder.LoadSystemPrompt();
-                var userMessage = MapEditorPromptBuilder.BuildUserMessage(mapContext, userInstructions);
-                var tools = AIToolConverter.ToSimpleFormat(MapEditorFunctions.GetToolDefinitions());
-
-                Debug.WriteLine($"[OpenCode] User instructions: {userInstructions}");
-                Debug.WriteLine($"[OpenCode] Tools count: {tools.Count}");
-
-                var allCommands = new List<string>();
-                var assistantNarrative = new List<string>();
-                int maxTurns = 40;
-
-                for (int turn = 0; turn < maxTurns; turn++)
+                foreach (var toolCall in result.ToolCallsMade)
                 {
-                    Debug.WriteLine($"[OpenCode] Turn {turn + 1}/{maxTurns}");
-
-                    var response = await SendMessageAsync(
-                        sessionId,
-                        userMessage,
-                        tools,
-                        systemPrompt,
-                        turn == 0); // First turn requires tools
-
-                    // Log raw response for debugging
-                    Debug.WriteLine($"[OpenCode] Raw response: {response?.ToString(Formatting.None)?.Substring(0, Math.Min(2000, response?.ToString(Formatting.None)?.Length ?? 0))}");
-
-                    var turnText = NormalizeAssistantNarrative(ExtractTextContent(response));
-                    if (!string.IsNullOrWhiteSpace(turnText) &&
-                        !assistantNarrative.Contains(turnText, StringComparer.Ordinal))
+                    if (toolCall == null || toolCall.IsError || string.IsNullOrWhiteSpace(toolCall.Name))
                     {
-                        assistantNarrative.Add(turnText);
-                    }
-
-                    var (commands, toolResponses, hasQueryFunctions) = ParseResponseWithQueries(response);
-
-                    Debug.WriteLine($"[OpenCode] Parsed commands ({commands.Count}): {string.Join(" | ", commands)}");
-                    Debug.WriteLine($"[OpenCode] Tool responses: {toolResponses.Count}, HasQueryFunctions: {hasQueryFunctions}");
-
-                    // Add all action commands to the result
-                    allCommands.AddRange(commands);
-
-                    // If there were query function calls, continue the conversation
-                    if (hasQueryFunctions && toolResponses.Count > 0)
-                    {
-                        // Send tool results back
-                        foreach (var (toolCallId, result, isError) in toolResponses)
-                        {
-                            response = await SendToolResultAsync(sessionId, toolCallId, result, isError);
-                        }
-
-                        var followUpText = NormalizeAssistantNarrative(ExtractTextContent(response));
-                        if (!string.IsNullOrWhiteSpace(followUpText) &&
-                            !assistantNarrative.Contains(followUpText, StringComparer.Ordinal))
-                        {
-                            assistantNarrative.Add(followUpText);
-                        }
-
-                        // Parse the follow-up response
-                        var (followUpCommands, _, _) = ParseResponseWithQueries(response);
-                        allCommands.AddRange(followUpCommands);
-
-                        // Update user message to empty for continuation (context is in session)
-                        userMessage = "";
                         continue;
                     }
 
-                    // No query functions, we're done
-                    break;
-                }
-
-                if (allCommands.Count == 0)
-                {
-                    Debug.WriteLine("[OpenCode] No commands generated - model returned no actionable tool calls or command text");
-                    if (assistantNarrative.Count > 0)
+                    if (MapEditorFunctions.IsQueryFunction(toolCall.Name))
                     {
-                        return string.Join(Environment.NewLine + Environment.NewLine, assistantNarrative);
+                        continue;
                     }
 
-                    // Final fallback: request a direct natural-language response so chat UI
-                    // still shows meaningful output even when no tools/commands were emitted.
                     try
                     {
-                        var fallbackPrompt = BuildNoCommandFallbackPrompt(mapContext, userInstructions);
-                        var directResponse = await SendSimplePromptAsync(
-                            "You are assisting a MapleStory map editor user. If no executable commands are needed, respond conversationally and concisely.",
-                            fallbackPrompt);
-
-                        if (!string.IsNullOrWhiteSpace(directResponse))
+                        var args = toolCall.Arguments != null
+                            ? JObject.FromObject(toolCall.Arguments)
+                            : new JObject();
+                        var command = MapEditorFunctions.FunctionCallToCommand(toolCall.Name, args);
+                        if (!string.IsNullOrWhiteSpace(command))
                         {
-                            return directResponse.Trim();
+                            AddUniqueCommands(allCommands, new[] { command });
                         }
                     }
                     catch (Exception ex)
                     {
-                        Debug.WriteLine($"[OpenCode] Direct fallback response failed: {ex.Message}");
+                        Debug.WriteLine($"[OpenCode] Failed to reconstruct command for {toolCall.Name}: {ex.Message}");
                     }
-
-                    return "I could not generate executable map commands for that request. Try asking for specific map edits, or ask a follow-up question.";
                 }
-
-                var finalResult = string.Join(Environment.NewLine, allCommands);
-                if (assistantNarrative.Count > 0)
-                {
-                    finalResult = string.Join(
-                        Environment.NewLine + Environment.NewLine,
-                        assistantNarrative.Concat(new[] { finalResult }));
-                }
-
-                Debug.WriteLine($"[OpenCode] Final result ({allCommands.Count} commands):\n{finalResult}");
-                return finalResult;
             }
-            finally
+
+            if (allCommands.Count > 0)
             {
-                // Clean up session
-                try
+                var finalCommands = string.Join(Environment.NewLine, allCommands);
+                Debug.WriteLine($"[OpenCode] Final commands ({allCommands.Count}):\n{finalCommands}");
+                return finalCommands;
+            }
+
+            if (!string.IsNullOrWhiteSpace(result.Text))
+            {
+                return result.Text.Trim();
+            }
+
+            try
+            {
+                var fallbackPrompt = BuildNoCommandFallbackPrompt(mapContext, userInstructions);
+                var directResponse = await SendSimplePromptAsync(
+                    "You are assisting a MapleStory map editor user. If no executable commands are needed, respond conversationally and concisely.",
+                    fallbackPrompt);
+
+                if (!string.IsNullOrWhiteSpace(directResponse))
                 {
-                    await DeleteSessionAsync(sessionId);
+                    return directResponse.Trim();
                 }
-                catch
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[OpenCode] Direct fallback response failed: {ex.Message}");
+            }
+
+            return "I could not generate executable map commands for that request. Try asking for specific map edits, or ask a follow-up question.";
+        }
+
+        private object ExecuteToolForProcessInstructions(string functionName, JObject arguments, List<string> localCommands)
+        {
+            arguments = arguments ?? new JObject();
+
+            if (MapEditorFunctions.IsQueryFunction(functionName))
+            {
+                _calledQueryFunctions.Add(functionName);
+                return MapEditorFunctions.ExecuteQueryFunction(functionName, arguments);
+            }
+
+            var requiredQuery = MapEditorFunctions.GetRequiredQuery(functionName);
+            if (requiredQuery != null && !_calledQueryFunctions.Contains(requiredQuery))
+            {
+                return MapEditorFunctions.GetQueryRequiredError(functionName, requiredQuery);
+            }
+
+            var command = MapEditorFunctions.FunctionCallToCommand(functionName, arguments);
+            if (!string.IsNullOrWhiteSpace(command))
+            {
+                localCommands.Add(command);
+            }
+
+            return $"Command queued: {functionName}";
+        }
+
+        private static void AddUniqueCommands(List<string> destination, IEnumerable<string> candidates)
+        {
+            if (destination == null || candidates == null)
+            {
+                return;
+            }
+
+            foreach (var candidate in candidates)
+            {
+                if (string.IsNullOrWhiteSpace(candidate))
                 {
-                    // Ignore cleanup errors
+                    continue;
+                }
+
+                if (!destination.Contains(candidate, StringComparer.Ordinal))
+                {
+                    destination.Add(candidate);
                 }
             }
         }

--- a/UnitTest_MapSimulator/AnimationControllerTests.cs
+++ b/UnitTest_MapSimulator/AnimationControllerTests.cs
@@ -1,5 +1,4 @@
-using HaCreator.MapSimulator;
-using HaCreator.MapSimulator.Objects.FieldObject;
+using HaCreator.MapSimulator.Animation;
 using HaSharedLibrary.Render.DX;
 using Moq;
 using System.Collections.Generic;

--- a/UnitTest_MapSimulator/CachedBoundaryCheckerTests.cs
+++ b/UnitTest_MapSimulator/CachedBoundaryCheckerTests.cs
@@ -1,4 +1,4 @@
-using HaCreator.MapSimulator;
+using HaCreator.MapSimulator.Core;
 using HaSharedLibrary.Render;
 using Xunit;
 using XnaRectangle = Microsoft.Xna.Framework.Rectangle;

--- a/UnitTest_MapSimulator/MobAITests.cs
+++ b/UnitTest_MapSimulator/MobAITests.cs
@@ -1,4 +1,4 @@
-using HaCreator.MapSimulator;
+using HaCreator.MapSimulator.AI;
 using Xunit;
 
 namespace UnitTest_MapSimulator
@@ -11,7 +11,7 @@ namespace UnitTest_MapSimulator
         private MobAI CreateDefaultMobAI()
         {
             var ai = new MobAI();
-            ai.Initialize(maxHp: 100, level: 10, exp: 50, isBoss: false, isUndead: false);
+            ai.Initialize(maxHp: 100, level: 10, exp: 50, isBoss: false, isUndead: false, autoAggro: true);
             ai.SetAggroRange(200);
             ai.SetAttackRange(50);
             ai.AddAttack(1, "attack1", damage: 10, range: 50, cooldown: 1000);
@@ -124,7 +124,7 @@ namespace UnitTest_MapSimulator
         public void Boss_HasIncreasedAggroRange()
         {
             var ai = new MobAI();
-            ai.Initialize(maxHp: 1000, level: 50, exp: 500, isBoss: true, isUndead: false);
+            ai.Initialize(maxHp: 1000, level: 50, exp: 500, isBoss: true, isUndead: false, autoAggro: true);
             ai.SetAggroRange(400);
 
             ai.Update(1000, 100, 100, 400, 100);

--- a/UnitTest_MapSimulator/MockGameTimeTests.cs
+++ b/UnitTest_MapSimulator/MockGameTimeTests.cs
@@ -1,4 +1,4 @@
-using HaCreator.MapSimulator;
+using HaCreator.MapSimulator.Core;
 using System;
 using Xunit;
 

--- a/UnitTest_MapSimulator/OpenCodeLiveTests.cs
+++ b/UnitTest_MapSimulator/OpenCodeLiveTests.cs
@@ -69,6 +69,108 @@ namespace UnitTest_MapSimulator
             }
         }
 
+        [Fact]
+        public async Task Live_OpenCodeRunWithTools_InvokesRegisteredProjectTool()
+        {
+            if (!IsLiveTestEnabled())
+            {
+                return;
+            }
+
+            var model = Environment.GetEnvironmentVariable("OPENCODE_LIVE_MODEL");
+            if (string.IsNullOrWhiteSpace(model))
+            {
+                model = "openai/gpt-5.3-codex";
+            }
+
+            var client = new OpenCodeClient(
+                host: "127.0.0.1",
+                port: 4096,
+                model: model,
+                autoStart: true,
+                reasoningEffort: "medium");
+
+            try
+            {
+                await client.EnsureServerAsync();
+                OpenCodeClient.ClearCollectedCommands();
+
+                var result = await client.RunWithToolsAsync(
+                    text: "Use remove_element exactly once with element_type='mob' x=10 y=20. After the tool returns, reply with done.",
+                    tools: MapEditorFunctions.GetToolDefinitions(),
+                    toolExecutor: (name, args) =>
+                    {
+                        return new JObject
+                        {
+                            ["unexpected_local_tool_executor"] = name
+                        };
+                    },
+                    systemPrompt: "You are running a tool invocation smoke test. You must use the provided tool when the user explicitly asks for a specific map edit action.",
+                    sessionTitle: "tool-smoke-test",
+                    maxIterations: 4,
+                    reasoningEffort: "low");
+
+                Assert.True(result.Success, result.Error ?? "OpenCode RunWithToolsAsync failed.");
+                Assert.NotNull(result.ToolCallsMade);
+                Assert.NotEmpty(result.ToolCallsMade);
+
+                var toolCall = Assert.Single(result.ToolCallsMade.Where(call => call.Name == "remove_element"));
+                Assert.False(toolCall.IsError);
+                Assert.Equal("mob", toolCall.Arguments["element_type"]?.ToString());
+                Assert.Equal("10", toolCall.Arguments["x"]?.ToString());
+                Assert.Equal("20", toolCall.Arguments["y"]?.ToString());
+                Assert.Contains("DELETE MOB at (10, 20)", OpenCodeClient.GetCollectedCommands());
+            }
+            finally
+            {
+                OpenCodeClient.StopServer();
+            }
+        }
+
+        [Fact]
+        public async Task Live_OpenCodeProcessInstructions_ReturnsServerSideCommand()
+        {
+            if (!IsLiveTestEnabled())
+            {
+                return;
+            }
+
+            var model = Environment.GetEnvironmentVariable("OPENCODE_LIVE_MODEL");
+            if (string.IsNullOrWhiteSpace(model))
+            {
+                model = "openai/gpt-5.3-codex";
+            }
+
+            var client = new OpenCodeClient(
+                host: "127.0.0.1",
+                port: 4096,
+                model: model,
+                autoStart: true,
+                reasoningEffort: "medium");
+
+            try
+            {
+                await client.EnsureServerAsync();
+
+                var mapContext =
+                    "# Map Summary" + Environment.NewLine +
+                    "Map: TestMap" + Environment.NewLine +
+                    "Content Bounds: X=[0 to 1000], Y=[0 to 1000]" + Environment.NewLine +
+                    "## Mobs" + Environment.NewLine +
+                    "- Mob at x=10, y=20";
+
+                var result = await client.ProcessInstructionsAsync(
+                    mapContext,
+                    "Remove the mob at x 10 y 20.");
+
+                Assert.Contains("DELETE MOB at (10, 20)", result);
+            }
+            finally
+            {
+                OpenCodeClient.StopServer();
+            }
+        }
+
         private static bool IsLiveTestEnabled()
         {
             var value = Environment.GetEnvironmentVariable("RUN_OPENCODE_LIVE_TEST");


### PR DESCRIPTION
Route ProcessInstructionsAsync through the RunWithTools path so server-side OpenCode project tools return executable map commands instead of falling back to prose.

Repair the affected unit/live tests and add live coverage for registered project tool execution and ProcessInstructionsAsync command output.